### PR TITLE
Improve config and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DB_SERVER=localhost
+DB_USERNAME=root
+DB_PASSWORD=password
+DB_NAME=test

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 .idea/
 # Ignore uploaded images
 image/
+uploads/
+.env
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ CKEditor. Posts are stored in a MySQL database.
 
 ## Setup
 1. Create a MySQL database using the SQL script from `sql/Dump20201031.sql`.
-2. Update `config.php` with your database credentials.
+2. Configure your database credentials. You can either edit `config.php` or set
+   the environment variables `DB_SERVER`, `DB_USERNAME`, `DB_PASSWORD` and `DB_NAME`.
+   A `.env.example` file is provided as a reference.
 3. Serve the project through a PHP-capable web server (e.g. `php -S` for local
    testing).
 

--- a/config.php
+++ b/config.php
@@ -1,9 +1,14 @@
 <?php
 
-define('DB_SERVER', 'localhost');
-define('DB_USERNAME', 'root');
-define('DB_PASSWORD', 'password');
-define('DB_NAME', 'test');
+$dbServer = getenv('DB_SERVER') ?: 'localhost';
+$dbUsername = getenv('DB_USERNAME') ?: 'root';
+$dbPassword = getenv('DB_PASSWORD') ?: 'password';
+$dbName = getenv('DB_NAME') ?: 'test';
+
+define('DB_SERVER', $dbServer);
+define('DB_USERNAME', $dbUsername);
+define('DB_PASSWORD', $dbPassword);
+define('DB_NAME', $dbName);
 
 $link = mysqli_connect(DB_SERVER, DB_USERNAME, DB_PASSWORD, DB_NAME);
 
@@ -12,9 +17,9 @@ if($link === false){
 }
 
 function GetALL() {
-    $link = mysqli_connect(DB_SERVER, DB_USERNAME, DB_PASSWORD, DB_NAME);
-    $sql = "select * from contents ORDER BY id DESC";
-    $result = $link->query($sql);
+    $conn = mysqli_connect(DB_SERVER, DB_USERNAME, DB_PASSWORD, DB_NAME);
+    $sql = "SELECT * FROM contents ORDER BY id DESC";
+    $result = $conn->query($sql);
     return $result;
 }
 ?>


### PR DESCRIPTION
## Summary
- support database configuration via environment variables
- document the new env vars and provide `.env.example`
- ignore runtime uploads

## Testing
- `php -l config.php`
- `php -l index.php create-post.php posts.php show.php register.php logout.php upload.php head.php ajaxfile.php`

------
https://chatgpt.com/codex/tasks/task_e_68444396090c83309ab57614b3672105